### PR TITLE
correct incorrect course duration

### DIFF
--- a/bootcamps/flatiron-school/programs/ios-program/data.yml
+++ b/bootcamps/flatiron-school/programs/ios-program/data.yml
@@ -4,7 +4,7 @@ cities:
 commitment: full-time
 cost_description: $15,000
 display_name: iOS Program
-duration: 11
+duration: 12
 duration_units: weeks
 financing: 'Yes'
 guarantee: 'No'

--- a/bootcamps/flatiron-school/programs/web-development/data.yml
+++ b/bootcamps/flatiron-school/programs/web-development/data.yml
@@ -4,7 +4,7 @@ cities:
 commitment: full-time
 cost_description: $15,000
 display_name: Full Stack Web Development
-duration: 11
+duration: 12
 duration_units: weeks
 financing: 'Yes'
 guarantee: 'No'


### PR DESCRIPTION
source: https://www.coursereport.com/blog/which-new-york-coding-bootcamp-is-best-for-you