### PR TITLE
Fix slugs, remove topics without pages, add Swift.

### DIFF
--- a/bootcamps/founders-and-coders/programs/primary/data.yml
+++ b/bootcamps/founders-and-coders/programs/primary/data.yml
@@ -13,18 +13,14 @@ program_slug: primary
 promises_job: true
 scholarships: 'Yes'
 topics:
-- Testing
-- JavaScript
-- Node.js
-- Hapi.js
-- React
-- Redux
-- Redis
-- PostgreSQL
-- AWS
-- HTML
-- CSS
-- Git
+- testing
+- javascript
+- node-js
+- react
+- postgresql
+- html
+- css
+- git
 tuition: 0
 tuition_units: "GBP \xA3"
 reports_graduation_and_placement_rates: "Yes"

--- a/bootcamps/lighthouse-labs/programs/Web-Development-Bootcamp/data.yml
+++ b/bootcamps/lighthouse-labs/programs/Web-Development-Bootcamp/data.yml
@@ -14,12 +14,12 @@ program_slug: web-development-bootcamp
 promises_job: false
 scholarships: 'No'
 topics:
-- JavaScript
-- Ruby on Rails
-- CSS
-- HTML
-- Node.JS
-- SQL
+- javascript
+- ruby-on-rails
+- css
+- html
+- node-js
+- sql
 tuition: 9000
 tuition_units: CAD
 reports_graduation_and_placement_rates: "Yes"

--- a/bootcamps/lighthouse-labs/programs/iOS-Development-Bootcamp/data.yml
+++ b/bootcamps/lighthouse-labs/programs/iOS-Development-Bootcamp/data.yml
@@ -14,11 +14,11 @@ program_slug: ios-bootcamp
 promises_job: false
 scholarships: 'No'
 topics:
-- iOS
-- Swift
-- Cocoa
-- Objective-C
-- Xcode
+- ios
+- swift
+- cocoa
+- objective-c
+- xcode
 tuition: 9000
 tuition_units: CAD
 reports_graduation_and_placement_rates: "Yes"

--- a/topics.yml
+++ b/topics.yml
@@ -60,6 +60,8 @@
   slug: html
 - display_name: iOS
   slug: ios
+- display_name: Swift
+  slug: swift
 - display_name: Jasmine
   slug: jasmine
 - display_name: Java


### PR DESCRIPTION
Change topics on Founders & Coders and Lighthouse Labs to use the slugs from our `topics.yml` file. Added Swift as an official topic, since I think that significantly contributes as it's own page, and removed a few topics from those bootcamps like Redux that aren't significant enough to be their own pages.