### PR TITLE
Name of bootcamp

### DIFF
--- a/bootcamps/flatiron-school/programs/ios-program/data.yml
+++ b/bootcamps/flatiron-school/programs/ios-program/data.yml
@@ -4,7 +4,7 @@ cities:
 commitment: full-time
 cost_description: $15,000
 display_name: iOS Program
-duration: 11
+duration: 12
 duration_units: weeks
 financing: 'Yes'
 guarantee: 'No'


### PR DESCRIPTION
The Software "Craftsmanship" Guild is now called the Software Guild. Thank you. 